### PR TITLE
Memory handler: Added missing mutex locks

### DIFF
--- a/memory_handler.go
+++ b/memory_handler.go
@@ -18,27 +18,47 @@ func NewMemoryHandler() *MemoryHandler {
 
 // LogEntry keep the message in memory.
 func (h *MemoryHandler) LogEntry(logEntry LogEntry) error {
-	h.mu.Lock()
-	defer h.mu.Unlock()
+	message := logEntry.GetMessage()
+	{
+		h.mu.Lock()
+		defer h.mu.Unlock()
 
-	h.log = append(h.log, h.prefix+logEntry.GetMessage())
-	return nil
+		h.log = append(h.log, h.prefix+message)
+		return nil
+	}
 }
 
 // SetPrefix adds a prefix to every log message.
 // Please note no space is added between the prefix and the log message
 func (h *MemoryHandler) SetPrefix(prefix string) Handler {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	h.prefix = prefix
 	return h
 }
 
 // Logs return a list of all the messages sent to the logger
 func (h *MemoryHandler) Logs() []string {
-	return h.log
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return append([]string(nil), h.log...)
+}
+
+// Empty return true when the internal list of logs is empty
+func (h *MemoryHandler) Empty() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return len(h.log) == 0
 }
 
 // Pop returns the latest log from the internal storage (and removes it)
 func (h *MemoryHandler) Pop() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	latest := h.log[len(h.log)-1]
 	h.log = h.log[:len(h.log)-1]
 	return latest

--- a/memory_handler_test.go
+++ b/memory_handler_test.go
@@ -36,4 +36,10 @@ func TestMemoryHandlerPop(t *testing.T) {
 	log := handler.Pop()
 	assert.Len(t, handler.Logs(), 2)
 	assert.Equal(t, "log 2", log)
+
+	assert.False(t, handler.Empty())
+	handler.Pop()
+	handler.Pop()
+	assert.True(t, handler.Empty())
+	assert.Panics(t, func() { handler.Pop() })
 }


### PR DESCRIPTION
Minor fix for MemoryHandler and use of Mutex, may not be mandatory but is more correct.