### PR TITLE
DefaultLogger: Buffer log output until the log output is configured

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -24,6 +24,7 @@ func NewFilteredConsoleLogger(minLevel LogLevel) *Logger {
 
 // SetHandler sets a new handler for the logger
 func (l *Logger) SetHandler(handler Handler) {
+	transferLogFromOverflowHandler(handler, l.handler)
 	l.handler = handler
 }
 

--- a/memory_handler.go
+++ b/memory_handler.go
@@ -1,18 +1,32 @@
 package clog
 
-import "sync"
+import (
+	"reflect"
+	"sync"
+	"sync/atomic"
+)
 
 // MemoryHandler save messages in memory (useful for unit testing).
 type MemoryHandler struct {
 	prefix string
 	log    []string
+	info   []memoryLogInfo
+	size   atomic.Int64
 	mu     sync.Mutex
 }
+
+type memoryLogInfo struct {
+	start int
+	level LogLevel
+}
+
+var memoryLogFixedSize = int64(reflect.TypeOf(memoryLogInfo{}).Size() + reflect.TypeOf("").Size())
 
 // NewMemoryHandler creates a new MemoryHandler that keeps logs in memory.
 func NewMemoryHandler() *MemoryHandler {
 	return &MemoryHandler{
-		log: make([]string, 0, 10),
+		log:  make([]string, 0, 10),
+		info: make([]memoryLogInfo, 0, 10),
 	}
 }
 
@@ -23,7 +37,15 @@ func (h *MemoryHandler) LogEntry(logEntry LogEntry) error {
 		h.mu.Lock()
 		defer h.mu.Unlock()
 
-		h.log = append(h.log, h.prefix+message)
+		if len(h.prefix) > 0 {
+			message = h.prefix + message
+		}
+		h.size.Add(memoryLogFixedSize + int64(len(message)))
+		h.log = append(h.log, message)
+		h.info = append(h.info, memoryLogInfo{
+			start: len(h.prefix),
+			level: logEntry.Level,
+		})
 		return nil
 	}
 }
@@ -37,6 +59,79 @@ func (h *MemoryHandler) SetPrefix(prefix string) Handler {
 	h.prefix = prefix
 	return h
 }
+
+// swap log between this and the other memory handler
+func (h *MemoryHandler) swap(other *MemoryHandler) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	other.mu.Lock()
+	defer other.mu.Unlock()
+
+	h.log, other.log = other.log, h.log
+	h.info, other.info = other.info, h.info
+	other.size.Store(h.size.Swap(other.Size()))
+	return
+}
+
+func (h *MemoryHandler) pop() (level LogLevel, startIdx int, message string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	tailIdx := len(h.log) - 1
+	level = h.info[tailIdx].level
+	startIdx = h.info[tailIdx].start
+	message = h.log[tailIdx]
+
+	h.size.Add(-(memoryLogFixedSize + int64(len(message))))
+	h.log = h.log[:tailIdx]
+	h.info = h.info[:tailIdx]
+	return
+}
+
+// Pop returns the latest log from the internal storage (and removes it)
+func (h *MemoryHandler) Pop() string {
+	_, _, latest := h.pop()
+	return latest
+}
+
+// PopWithLevel returns the latest log from the internal storage (and removes it)
+func (h *MemoryHandler) PopWithLevel() (level LogLevel, prefix, message string) {
+	var start int
+	level, start, message = h.pop()
+	prefix = message[:start]
+	message = message[start:]
+	return
+}
+
+// TransferTo transfers (and removes) all messages from the internal storage to another handler.
+// Returns true as messages were transferred.
+func (h *MemoryHandler) TransferTo(receiver Handler) bool {
+	if receiver == h {
+		return false
+	}
+
+	// swap log and release mutex before sending to receiver
+	local := NewMemoryHandler()
+	local.swap(h)
+
+	// calldepth is not supported as the caller is TransferTo, skipping all stack frames
+	const depth = 1_000
+
+	if receiver != nil {
+		for i, message := range local.log {
+			info := local.info[i]
+			if info.start > 0 {
+				message = message[info.start:]
+			}
+			_ = receiver.LogEntry(NewLogEntry(depth, info.level, message))
+		}
+	}
+
+	return len(local.log) > 0
+}
+
+// Reset clears internally buffered log
+func (h *MemoryHandler) Reset() { h.swap(NewMemoryHandler()) }
 
 // Logs return a list of all the messages sent to the logger
 func (h *MemoryHandler) Logs() []string {
@@ -54,14 +149,9 @@ func (h *MemoryHandler) Empty() bool {
 	return len(h.log) == 0
 }
 
-// Pop returns the latest log from the internal storage (and removes it)
-func (h *MemoryHandler) Pop() string {
-	h.mu.Lock()
-	defer h.mu.Unlock()
-
-	latest := h.log[len(h.log)-1]
-	h.log = h.log[:len(h.log)-1]
-	return latest
+// Size return the estimated amount of memory used by this handler
+func (h *MemoryHandler) Size() int64 {
+	return h.size.Load()
 }
 
 // Verify interface

--- a/memory_handler_test.go
+++ b/memory_handler_test.go
@@ -24,6 +24,7 @@ func TestMemoryHandlerConcurrency(t *testing.T) {
 	for _, entry := range handler.Logs() {
 		assert.Len(t, entry, 7)
 	}
+	assert.Equal(t, (memoryLogFixedSize+7)*int64(iterations), handler.Size())
 }
 
 func TestMemoryHandlerPop(t *testing.T) {
@@ -42,4 +43,79 @@ func TestMemoryHandlerPop(t *testing.T) {
 	handler.Pop()
 	assert.True(t, handler.Empty())
 	assert.Panics(t, func() { handler.Pop() })
+}
+
+func TestMemoryHandlerPopWithLevel(t *testing.T) {
+	handler := NewMemoryHandler()
+	logger := NewLogger(handler)
+	logger.SetPrefix("prefix:")
+	logger.Error("err-msg")
+	logger.Info("i2")
+	logger.Info("i1")
+
+	assert.Len(t, handler.Logs(), 3)
+	assert.Equal(t, "prefix:i1", handler.Pop())
+
+	level, prefix, message := handler.PopWithLevel()
+	assert.Equal(t, LevelInfo, level)
+	assert.Equal(t, "prefix:", prefix)
+	assert.Equal(t, "i2", message)
+
+	level, prefix, message = handler.PopWithLevel()
+	assert.Equal(t, LevelError, level)
+	assert.Equal(t, "prefix:", prefix)
+	assert.Equal(t, "err-msg", message)
+}
+
+func TestMemoryHandlerReset(t *testing.T) {
+	handler := NewMemoryHandler()
+	NewLogger(handler).Info("info")
+	assert.False(t, handler.Empty())
+	handler.Reset()
+	assert.True(t, handler.Empty())
+}
+
+func TestMemoryHandlerTransferTo(t *testing.T) {
+	handler := NewMemoryHandler()
+	logger := NewLogger(handler)
+	for i := 0; i < 3; i++ {
+		logger.Warningf("log %d", i)
+	}
+
+	assert.Len(t, handler.Logs(), 3)
+	assert.False(t, handler.TransferTo(handler))
+
+	dest := NewMemoryHandler()
+	for i := 0; i < 2; i++ {
+		assert.Equal(t, i == 0, handler.TransferTo(dest))
+		assert.Len(t, handler.Logs(), 0)
+		assert.Len(t, dest.Logs(), 3)
+	}
+
+	assert.Panics(t, func() { handler.Pop() })
+	assert.Equal(t, []string{"log 0", "log 1", "log 2"}, dest.Logs())
+
+	level, _, message := dest.PopWithLevel()
+	assert.Equal(t, LevelWarning, level)
+	assert.Equal(t, "log 2", message)
+
+	assert.Len(t, dest.Logs(), 2)
+	assert.True(t, dest.TransferTo(nil))
+	assert.Empty(t, dest.Logs())
+}
+
+func TestMemoryHandlerTransferToPrefix(t *testing.T) {
+	handler := NewMemoryHandler()
+	logger := NewLogger(handler)
+	logger.SetPrefix("prefix ")
+	for i := 0; i < 3; i++ {
+		logger.Warningf("log %d", i)
+	}
+
+	assert.Equal(t, "prefix log 2", handler.Pop())
+
+	// TransferTo strips logger specific prefix
+	receiver := NewMemoryHandler()
+	handler.TransferTo(receiver)
+	assert.Equal(t, []string{"log 0", "log 1"}, receiver.Logs())
 }

--- a/overflow_handler.go
+++ b/overflow_handler.go
@@ -1,0 +1,51 @@
+package clog
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// overflowHandler is a MemoryHandler that calls overflow func when the size of
+// recorded messages reaches or exceeds the specified overflowSize.
+type overflowHandler struct {
+	MemoryHandler
+	overflow     func()
+	overflowSize int64
+}
+
+func newOverflowHandler(overflow func(*overflowHandler), overflowSize int64) (handler *overflowHandler) {
+	once := new(atomic.Pointer[sync.Once])
+	once.Store(new(sync.Once))
+
+	handleOverflow := func() {
+		once.Load().Do(func() {
+			defer once.Store(new(sync.Once))
+			defer handler.Reset()
+			overflow(handler)
+		})
+	}
+
+	handler = &overflowHandler{
+		MemoryHandler: *NewMemoryHandler(),
+		overflow:      handleOverflow,
+		overflowSize:  overflowSize,
+	}
+	return
+}
+
+// Transfers all buffered messages from the specified src to dest, if the src is an overflowHandler
+func transferLogFromOverflowHandler(dst, src Handler) {
+	if ofh, ok := src.(*overflowHandler); ok && src != nil {
+		for ofh.TransferTo(dst) {
+		}
+	}
+}
+
+func (o *overflowHandler) LogEntry(entry LogEntry) error {
+	defer func() {
+		if o.Size() > o.overflowSize {
+			o.overflow()
+		}
+	}()
+	return o.MemoryHandler.LogEntry(entry)
+}

--- a/overflow_handler_test.go
+++ b/overflow_handler_test.go
@@ -1,0 +1,35 @@
+package clog
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverflow(t *testing.T) {
+	var logs []string
+	handler := newOverflowHandler(func(handler *overflowHandler) {
+		logs = handler.Logs()
+	}, 1024)
+	logger := NewLogger(handler)
+
+	for retry := 0; retry < 3; retry++ {
+		logs = nil
+		line := 0
+		for logs == nil {
+			assert.Equal(t, handler.Size() == 0, handler.Empty())
+			logger.Infof("-- %03d", line)
+			line++
+		}
+
+		assert.Equal(t, 27, line)
+		assert.True(t, handler.Empty())
+		assert.Equal(t, int64(0), handler.Size())
+
+		assert.NotNil(t, logs)
+		for i := 0; i < line; i++ {
+			assert.Equal(t, fmt.Sprintf("-- %03d", i), logs[i])
+		}
+	}
+}


### PR DESCRIPTION
Prevents any log output from the default logger until a log output handler or a new default logger is configured.

Log is buffered by up to 2MB and discarded completely if the buffer is exceeded and no output was configured. Any buffered log is sent to the output handler when set.